### PR TITLE
Suggestions for v1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,10 @@ Parameters:
   -v| --version   Show the version (v1.0.4) of git-redate
   -l| --limit N   Process commits in chunks/batches of size N, default=20.
 ```
+
+## Editor preferences
+
+1. If the environment variable `EDITOR` is set, this setting will be used. You can set it with `export EDITOR=vim` if you want to use `vim`.
+2. Without `EDITOR` the settings file `~/.git-redate-settings` is checked. If it does not exist, `git-redate` will ask you to specify and editor (`nano`, `vi` or `custom`) and write it to this file.
+
+The environment variable overrides the settings file anytime it is set.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # git-redate
-### Made by [Potato Labs](http://taterlabs.com) and [eXtronis](https://extronis.com)
 
 Interactively change the dates of several git commits in current branch with a single command. Improved and updated fork.
 
@@ -49,3 +48,9 @@ Parameters:
 2. Without `EDITOR` the settings file `~/.git-redate-settings` is checked. If it does not exist, `git-redate` will ask you to specify and editor (`nano`, `vi` or `custom`) and write it to this file.
 
 The environment variable overrides the settings file anytime it is set.
+
+# Contributors
+
+* [PotatoLabs](https://github.com/PotatoLabs)
+* [eXtronics](http://extronis.com/)
+* [Christian Lölkes](https://github.com/loelkes)

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Interactively change the dates of several git commits in current branch with a s
 
 # Installation
 
-For Homebrew users (on macOS): you need to run `brew tap PotatoLabs/homebrew-git-redate` and then `brew install git-redate`. See Homebrew formula here: https://github.com/PotatoLabs/homebrew-git-redate
+When using Linux/BSD/Unix or macOS: you can clone this repo or download the `git-redate` file and copy it into any folders in your $PATH. Restart your terminal afterwards and you're good to go!
 
-When using Linux/BSD/Unix or macOS without Homebrew: you can clone this repo or download the `git-redate` file and copy it into any folders in your $PATH. Restart your terminal afterwards and you're good to go!
+If you're using Homebrew please note that the available version (1.0.2) is outdated.
 
 For Windows users: you copy the `git-redate` file into `${INSTALLATION_PATH}\mingw64\libexec\git-core\`. If you used the default Git installation settings, `INSTALLATION_PATH` should be `C:\Program Files\Git`.
 
@@ -32,5 +32,13 @@ Examples: \
 * Specify block size ("chunks") of commits to process: `--limit | -l <block size>`.
 * Enable debug output: `--debug | -d`.
 
-
-
+## CLI arguments
+```
+Parameters:
+  -a| --all       Process all commits. Use this if number of commits is 1 or -c would reach to first commit.
+  -c| --commits N Process last N commits, default=5.
+  -d| --debug     Enable debug output.
+  -h| --help      Show this help message.
+  -v| --version   Show the version (v1.0.4) of git-redate
+  -l| --limit N   Process commits in chunks/batches of size N, default=20.
+```

--- a/git-redate
+++ b/git-redate
@@ -119,14 +119,21 @@ else
     fi
 fi
 
+# Add a newline to the file.
+echo '' >> $tmpfile
+
+# If the file does not end with a empty line some editors (like nano) will add one even if you save
+# the file without doing any modifications. In this case, the md5 hash is different even if the user
+# did not change any content. Adding a newline is a workaround for this.
+
 # Save modification timestamp of file
-TMPFILE_MOD_INITIAL_TIMESTAMP=$( stat --format=%Y $tmpfile )
+TMPFILE_MOD_INITIAL_TIMESTAMP=$( openssl md5 $tmpfile )
 
 # Edit file
 ${VISUAL:-${EDITOR:-${OUR_EDITOR}}} $tmpfile
 
 # Retrieve current modification timestamp of file
-TMPFILE_MOD_CURRENT_TIMESTAMP=$( stat --format=%Y $tmpfile )
+TMPFILE_MOD_CURRENT_TIMESTAMP=$( openssl md5 $tmpfile )
 
 # Stop here if no changes were made
 if [[ "${TMPFILE_MOD_INITIAL_TIMESTAMP}" = "${TMPFILE_MOD_CURRENT_TIMESTAMP}" ]] ; then

--- a/git-redate
+++ b/git-redate
@@ -80,7 +80,7 @@ while [[ $# -ge 1 ]] ; do
             echo "  -c| --commits N Process last N commits, default=5."
             echo "  -d| --debug     Enable debug output."
             echo "  -h| --help      Show this help message."
-            echo "  -v| --version   Show the version (${VERSION}) of git-redate"
+            echo "  -v| --version   Show the version of git-redate"
             echo "  -l| --limit N   Process commits in chunks/batches of size N, default=20."
             if [ -f "$SETTINGS_FILE" ]; then
                 echo "Configuration (${SETTINGS_FILE}):"

--- a/git-redate
+++ b/git-redate
@@ -61,7 +61,13 @@ while [[ $# -ge 1 ]] ; do
             ;;
         -c| --commits)
             shift
-            if [[ "$1" =~ ^[1-9][0-9]*$ ]]; then COMMITS=$1; shift; else echo "ERROR: invalid commits count: '$1'"; exit 2; fi
+            if [[ "$1" =~ ^[1-9][0-9]*$ ]]; then
+                COMMITS=$1
+                shift
+            else
+                echo "ERROR: invalid commits count: '$1'"
+                exit 2
+            fi
             ;;
         -d| --debug)
             shift
@@ -89,7 +95,13 @@ while [[ $# -ge 1 ]] ; do
             ;;
         -l| --limit)
             shift
-            if [[ "$1" =~ ^[1-9][0-9]*$ ]]; then LIMITCHUNKS=$1; shift; else echo "ERROR: invalid limit size: '$1'"; exit 2; fi
+            if [[ "$1" =~ ^[1-9][0-9]*$ ]]; then
+                LIMITCHUNKS=$1
+                shift
+            else
+                echo "ERROR: invalid limit size: '$1'"
+                exit 2
+            fi
             ;;
         *)
             # unknown option

--- a/git-redate
+++ b/git-redate
@@ -48,6 +48,20 @@ is_has_editor() {
     fi
 }
 
+show_editor_preference() {
+    if [ -f "$SETTINGS_FILE" ]; then
+        echo "Configuration (${SETTINGS_FILE}):"
+        cat "${SETTINGS_FILE}"
+    else
+        echo "Configuration file ${SETTINGS_FILE} does not exist yet."
+    fi
+    if [ ! -z "$EDITOR" ]; then
+        echo "Environment EDITOR: ${EDITOR}"
+    else
+        echo "Environment variable EDITOR is not set."
+    fi
+}
+
 ALL=0
 COMMITS=5
 DEBUG=0
@@ -82,10 +96,7 @@ while [[ $# -ge 1 ]] ; do
             echo "  -h| --help      Show this help message."
             echo "  -v| --version   Show the version of git-redate"
             echo "  -l| --limit N   Process commits in chunks/batches of size N, default=20."
-            if [ -f "$SETTINGS_FILE" ]; then
-                echo "Configuration (${SETTINGS_FILE}):"
-                cat "${SETTINGS_FILE}"
-            fi
+            show_editor_preference
             exit 0
             ;;
         -v| --version)

--- a/git-redate
+++ b/git-redate
@@ -164,7 +164,10 @@ if [[ "${TMPFILE_MOD_INITIAL_TIMESTAMP}" = "${TMPFILE_MOD_CURRENT_TIMESTAMP}" ]]
     exit 0
 fi
 
-cat "$tmpfile"
+if [ "${DEBUG}" -eq 1 ]; then
+    echo "The following changes will be applied:"
+    cat "$tmpfile"
+fi
 
 ITER=0
 COLITER=0
@@ -250,4 +253,3 @@ else
     echo "ERROR! Please make sure you run this on a clean working directory."
     exit 1
 fi
-

--- a/git-redate
+++ b/git-redate
@@ -2,6 +2,7 @@
 # vi: set expandtab ts=4 sw=4:
 
 SETTINGS_FILE=~/.git-redate-settings
+VERSION=v1.0.4
 
 is_git_repo() {
     git rev-parse --show-toplevel > /dev/null 2>&1
@@ -73,9 +74,15 @@ while [[ $# -ge 1 ]] ; do
             echo "  -c| --commits N Process last N commits, default=5."
             echo "  -d| --debug     Enable debug output."
             echo "  -h| --help      Show this help message."
+            echo "  -v| --version   Show the version (${VERSION}) of git-redate"
             echo "  -l| --limit N   Process commits in chunks/batches of size N, default=20."
             echo "Configuration (${SETTINGS_FILE}):"
             cat "${SETTINGS_FILE}"
+            exit 0
+            ;;
+        -v| --version)
+            shift
+            echo "${VERSION}"
             exit 0
             ;;
         -l| --limit)

--- a/git-redate
+++ b/git-redate
@@ -12,8 +12,6 @@ is_git_repo() {
   fi
 }
 
-is_git_repo
-
 make_editor_choice() {
     echo -e "Which editor do you want to use for this repo?\n";
     echo -e "1. VI\n";
@@ -48,8 +46,6 @@ is_has_editor() {
         echo ${OUR_EDITOR} > ${SETTINGS_FILE}
     fi
 }
-
-is_has_editor
 
 ALL=0
 COMMITS=5
@@ -98,6 +94,12 @@ die () {
     echo >&2 `basename $0`: $*
     exit 1
 }
+
+# Check if working directory is a git repo
+is_git_repo
+
+# Check if editor preferences are set
+is_has_editor
 
 tmpfile=$(mktemp gitblah-XXXXX)
 [ -f "$tmpfile" ] || die "could not get tmpfile=[$tmpfile]"

--- a/git-redate
+++ b/git-redate
@@ -76,8 +76,10 @@ while [[ $# -ge 1 ]] ; do
             echo "  -h| --help      Show this help message."
             echo "  -v| --version   Show the version (${VERSION}) of git-redate"
             echo "  -l| --limit N   Process commits in chunks/batches of size N, default=20."
-            echo "Configuration (${SETTINGS_FILE}):"
-            cat "${SETTINGS_FILE}"
+            if [ -f "$SETTINGS_FILE" ]; then
+                echo "Configuration (${SETTINGS_FILE}):"
+                cat "${SETTINGS_FILE}"
+            fi
             exit 0
             ;;
         -v| --version)

--- a/git-redate
+++ b/git-redate
@@ -30,10 +30,10 @@ get_editor_executable() {
 
 
 is_has_editor() {
-    if [ -f "$SETTINGS_FILE" ]; then
-        OUR_EDITOR=$(cat ${SETTINGS_FILE});
-    elif [ ! -z "$EDITOR" ]; then
+    if [ ! -z "$EDITOR" ]; then
         OUR_EDITOR="$EDITOR";
+    elif [ -f "$SETTINGS_FILE" ]; then
+        OUR_EDITOR=$(cat ${SETTINGS_FILE});
     else
         make_editor_choice
         if [ ${CHOOSE_EDITOR} == 3 ] || [ ${CHOOSE_EDITOR} == "3" ]; then


### PR DESCRIPTION
* Replace `stat` with `openssl md5` for better compatibility
* Introduce -v | --version CLI argument
* Parse CLI arguments before checks so -h | --help or -v | --version can be used anytime.
* Update README.md
